### PR TITLE
add stack.yaml files to subdirectories

### DIFF
--- a/kubeconfig/stack.yaml
+++ b/kubeconfig/stack.yaml
@@ -1,0 +1,3 @@
+resolver: lts-10.0
+packages:
+- .

--- a/kubernetes-client-helper/stack.yaml
+++ b/kubernetes-client-helper/stack.yaml
@@ -1,0 +1,3 @@
+resolver: lts-10.0
+packages:
+- .


### PR DESCRIPTION
The `kubeconfig` and `Kubernetes-client-helper` sub-projects don't have individual `stack.yaml` files. This PR adds them and so makes these sub-projects usable with the `stack` build tool.

Since these packages aren't on hackage, then one easy way to get them using `stack` is to point to this GitHub project and list the `kubeconfig` and `kubernetes-client-helper` as subdirs. They are each required to have stack.yaml files though. 

I used the `lts-10.0` resolver field, but I'm actually building them with the `lts-11.10` snapshot (and `allow-newer: true` and everything works just fine.