### PR TITLE
Fix FromJSON/ToJSON instances of CustomTypes (IntOrString and Quantity)

### DIFF
--- a/kubernetes/lib/Kubernetes/OpenAPI/CustomTypes.hs
+++ b/kubernetes/lib/Kubernetes/OpenAPI/CustomTypes.hs
@@ -4,8 +4,10 @@
 module Kubernetes.OpenAPI.CustomTypes where
 
 import Data.Aeson (FromJSON, ToJSON)
+import qualified Data.Aeson as A
 import Data.Data (Typeable)
 import Data.Text (Text)
+import GHC.Base (mzero)
 
 import GHC.Generics
 
@@ -18,7 +20,16 @@ import GHC.Generics
 data IntOrString
   = IntOrStringS Text
   | IntOrStringI Int
-  deriving (Show, Eq, ToJSON, FromJSON, Typeable, Generic)
+  deriving (Show, Eq, Typeable, Generic)
+
+instance FromJSON IntOrString where
+  parseJSON (A.String t) = return $ IntOrStringS t
+  parseJSON (A.Number n) = return $ IntOrStringI (round n)
+  parseJSON _ = mzero
+
+instance ToJSON IntOrString where
+  toJSON (IntOrStringS t) = A.String t
+  toJSON (IntOrStringI n) = A.Number (fromIntegral n)
 
 {- | `Quantity` is a fixed-point representation of a number.
   
@@ -78,4 +89,11 @@ data IntOrString
   that will cause implementors to also use a fixed point implementation.
 -}
 newtype Quantity = Quantity { unQuantity :: Text }
-  deriving (Show, Eq, ToJSON, FromJSON, Typeable, Generic)
+  deriving (Show, Eq, Typeable, Generic)
+
+instance FromJSON Quantity where
+  parseJSON (A.String t) = return $ Quantity t
+  parseJSON _ = mzero
+
+instance ToJSON Quantity where
+  toJSON (Quantity t) = A.String t


### PR DESCRIPTION
The automatically derived `FromJSON`/`ToJSON` instances for these types aren't correct.

For `IntOrString`, I added explicit instances that make the behavior match what the comment says. Now this type encodes/decodes to a raw number or string. Formerly it would encode to Aeson's default, a tagged object, something like `{"tag": "IntOrStringS", "value": "foo"}`/`{"tag": "IntOrStringI", "value": 42}` or similar (I didn't check exactly).

For `Quantity`, I added instances that encode/decode to `Text`, which is a step in the direction, but the type still doesn't match the comment about the full serialization scheme. Formerly this too would encode to a tagged object.

I confirmed these work for parsing real Kubernetes values.

Note these instances could possibly be derived more concisely with Aeson's `UntaggedValue` `SumEncoding`, but I think it's clearer this way.