### PR TITLE
Make preferences in kubeconfig optional

### DIFF
--- a/kubernetes-client/src/Kubernetes/Client/KubeConfig.hs
+++ b/kubernetes-client/src/Kubernetes/Client/KubeConfig.hs
@@ -43,7 +43,7 @@ camelToWithOverrides c overrides = defaultOptions
 data Config = Config
   { kind           :: Maybe Text
   , apiVersion     :: Maybe Text
-  , preferences    :: Preferences
+  , preferences    :: Maybe Preferences
   , clusters       :: [NamedEntity Cluster "cluster"]
   , authInfos      :: [NamedEntity AuthInfo "user"]
   , contexts       :: [NamedEntity Context "context"]


### PR DESCRIPTION
I couldn't find any docs on the structure of the kubeconfig file, but`kubectl` runs fine without the `preferences` key in the config.