### PR TITLE
Update resolver to be in sync with core package

### DIFF
--- a/kubernetes/kubernetes-client-core.cabal
+++ b/kubernetes/kubernetes-client-core.cabal
@@ -1,5 +1,5 @@
 name:           kubernetes-client-core
-version:        0.1.0.0
+version:        0.1.0.1
 synopsis:       Auto-generated kubernetes-client-core API Client
 description:    .
                 Client library for calling the Kubernetes API based on http-client.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-10.0
+resolver: lts-13.9
 extra-deps:
 - katip-0.8.0.0
 packages:


### PR DESCRIPTION
This will fix generated upper bound for the exception package

As mentioned in this comment: https://github.com/kubernetes-client/haskell/issues/23#issuecomment-510087570