### PR TITLE
Add lower bounds to client deps

### DIFF
--- a/kubernetes-client/package.yaml
+++ b/kubernetes-client/package.yaml
@@ -29,21 +29,21 @@ extra-source-files:
 dependencies:
   - base >=4.7 && <5.0
   - bytestring >=0.10.0 && <0.11
-  - aeson >=1.2.2 && <2.0
-  - connection
-  - containers
-  - data-default-class
-  - http-client >=0.5 && <0.6
-  - http-client-tls
-  - kubernetes-client-core == 0.1.0.0
-  - microlens >= 0.4.3 && <0.5
+  - aeson >=1.2.2 && <1.5
+  - connection >=0.2.8
+  - containers >= 0.6.0.1
+  - data-default-class >=0.1.2.0
+  - http-client >=0.5 && <0.7
+  - http-client-tls >=0.3.5.3
+  - kubernetes-client-core ==0.1.0.1
+  - microlens >=0.4.3 && <0.5
   - mtl >=2.2.1
-  - pem
-  - safe-exceptions <0.2
+  - pem >=0.2.4
+  - safe-exceptions >=0.1.0.0
   - streaming-bytestring >= 0.1.5 && < 0.2.0
   - text >=0.11 && <1.3
-  - tls
-  - x509
-  - x509-system
-  - x509-store
-  - x509-validation
+  - tls >=1.4.1
+  - x509 >=1.7.5
+  - x509-system >=1.6.6
+  - x509-store >=1.6.7
+  - x509-validation >=1.6.11


### PR DESCRIPTION
They can possibly be lowered even more, but I couldn't find any nice/automated way of doing that.

This change is required because as we update stackage resolvers over time, `stack sdist` starts putting newer versions in lower bounds which is not nice, so in order to preserve them I've added them to package.yaml.

I have also updated the upper bounds where they were specified to make sure latest versions of those packages will work.

I could've added upper bounds also to the package.yaml, but decided not to because I wasn't sure if would be useful. As of now `packdeps` reports that all the versions are fine except a few dependencies of `kubernetes-client-core`, we'll need to update codegen for this to be up to date.