### PR TITLE
Bump version of kubernetes-client to match core

### DIFF
--- a/kubernetes-client/package.yaml
+++ b/kubernetes-client/package.yaml
@@ -1,5 +1,5 @@
 name: kubernetes-client
-version: 0.2.0.0
+version: 0.3.0.0
 description: |
   Client library for interacting with a Kubernetes cluster.
 


### PR DESCRIPTION
Since we have added `kubernetes-client-core ==0.3.0.0` to the dependencies of the client package, I guess we should just keep them in sync.