### PR TITLE
Support hoauth2 >= 1.11

### DIFF
--- a/kubernetes-client/package.yaml
+++ b/kubernetes-client/package.yaml
@@ -1,5 +1,5 @@
 name: kubernetes-client
-version: 0.3.1.0
+version: 0.3.2.0
 description: |
   Client library for interacting with a Kubernetes cluster.
 
@@ -45,7 +45,7 @@ dependencies:
   - data-default-class >=0.1
   - either >=5.0
   - filepath >=1.4
-  - hoauth2 >=1.8
+  - hoauth2 >=1.11
   - http-client >=0.5 && <0.7
   - http-client-tls >=0.3
   - jose-jwt >=0.8

--- a/kubernetes-client/src/Kubernetes/Client/Auth/OIDC.hs
+++ b/kubernetes-client/src/Kubernetes/Client/Auth/OIDC.hs
@@ -94,7 +94,7 @@ fetchToken auth@(OIDCAuth{..}) = do
       tokenURI <- parseURI strictURIParserOptions (Text.encodeUtf8 tokenEndpoint)
                   & either (throwM . OIDCURIException) pure
       let oauth = OAuth2{ oauthClientId = clientID
-                        , oauthClientSecret = clientSecret
+                        , oauthClientSecret = Just clientSecret
                         , oauthAccessTokenEndpoint = tokenURI
                         , oauthOAuthorizeEndpoint = tokenURI
                         , oauthCallback = Nothing

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,7 @@ extra-deps:
 - jsonpath-0.1.0.1
 - jwt-0.10.0
 - oidc-client-0.4.0.0
+- hoauth2-1.16.0
 packages:
 - kubernetes
 - kubernetes-client

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -25,6 +25,13 @@ packages:
       sha256: 68c285c6365360975d50bbb18cb07755d5ef19af8bf0e998d3ea46d35ef4a4e1
   original:
     hackage: oidc-client-0.4.0.0
+- completed:
+    hackage: hoauth2-1.16.0@sha256:161b20369ce80cd8348e448e3b307e7850c3d21e8ae4f1e258dbd04d0da34a65,5629
+    pantry-tree:
+      size: 2046
+      sha256: 55931b378faa4a89275c572ecf9a5ec65a7a71f092819e4f704a285a7d4f6f35
+  original:
+    hackage: hoauth2-1.16.0
 snapshots:
 - completed:
     size: 523700


### PR DESCRIPTION
This commit drops support for hoauth2 < 1.11

Fixes #80 