### PR TITLE
Remove inactive members from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,14 +2,15 @@
 approvers:
 - brendandburns
 - guoshimin
-- mbohlool
 - jkachmar
 - jonschoning
 - akshaymankar
 reviewers:
 - brendandburns
 - guoshimin
-- mbohlool
 - jkachmar
 - jonschoning
 - akshaymankar
+emeritus_approvers:
+- mbohlool
+


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/2456

As a part of cleaning up inactive members (those with no activity within
the past 18 months) from OWNERS files, this commit moves mbohlool from
an approver to emeritus_approver.