### PR TITLE
Add Exec authentication method

### DIFF
--- a/kubernetes-client/kubernetes-client.cabal
+++ b/kubernetes-client/kubernetes-client.cabal
@@ -29,6 +29,7 @@ library
       Kubernetes.Client
       Kubernetes.Client.Auth.Basic
       Kubernetes.Client.Auth.ClientCert
+      Kubernetes.Client.Auth.Exec
       Kubernetes.Client.Auth.GCP
       Kubernetes.Client.Auth.Internal.Types
       Kubernetes.Client.Auth.OIDC
@@ -55,6 +56,7 @@ library
     , data-default-class >=0.1
     , either >=5.0
     , filepath >=1.4
+    , hashable
     , hoauth2 >=1.11 && <=3
     , http-client >=0.5 && <0.8
     , http-client-tls >=0.3
@@ -65,6 +67,7 @@ library
     , mtl >=2.2
     , oidc-client >=0.4
     , pem >=0.2
+    , process
     , safe-exceptions >=0.1.0.0
     , stm >=2.4
     , streaming-bytestring >=0.1 && <0.3
@@ -73,6 +76,7 @@ library
     , timerep >=2.0
     , tls >=1.4.1
     , typed-process >=0.2
+    , unordered-containers
     , uri-bytestring >=0.3
     , x509 >=1.7
     , x509-store >=1.6
@@ -99,6 +103,7 @@ test-suite example
     , data-default-class >=0.1
     , either >=5.0
     , filepath >=1.4
+    , hashable
     , hoauth2 >=1.11 && <=3
     , http-client >=0.5 && <0.8
     , http-client-tls >=0.3
@@ -110,6 +115,7 @@ test-suite example
     , mtl >=2.2
     , oidc-client >=0.4
     , pem >=0.2
+    , process
     , safe-exceptions >=0.1.0.0
     , stm >=2.4
     , streaming-bytestring >=0.1 && <0.3
@@ -118,6 +124,7 @@ test-suite example
     , timerep >=2.0
     , tls >=1.4.1
     , typed-process >=0.2
+    , unordered-containers
     , uri-bytestring >=0.3
     , x509 >=1.7
     , x509-store >=1.6
@@ -150,6 +157,7 @@ test-suite spec
     , either >=5.0
     , file-embed
     , filepath >=1.4
+    , hashable
     , hoauth2 >=1.11 && <=3
     , hspec
     , hspec-attoparsec
@@ -163,6 +171,7 @@ test-suite spec
     , mtl >=2.2
     , oidc-client >=0.4
     , pem >=0.2
+    , process
     , safe-exceptions >=0.1.0.0
     , stm >=2.4
     , streaming-bytestring >=0.1 && <0.3
@@ -171,6 +180,7 @@ test-suite spec
     , timerep >=2.0
     , tls >=1.4.1
     , typed-process >=0.2
+    , unordered-containers
     , uri-bytestring >=0.3
     , x509 >=1.7
     , x509-store >=1.6

--- a/kubernetes-client/kubernetes-client.cabal
+++ b/kubernetes-client/kubernetes-client.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.1.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -70,8 +70,8 @@ library
     , process
     , safe-exceptions >=0.1.0.0
     , stm >=2.4
-    , streaming-bytestring >=0.1 && <0.3
-    , text >=0.11 && <1.3
+    , streaming-bytestring >=0.1
+    , text >=0.11
     , time >=1.8
     , timerep >=2.0
     , tls >=1.4.1
@@ -118,8 +118,8 @@ test-suite example
     , process
     , safe-exceptions >=0.1.0.0
     , stm >=2.4
-    , streaming-bytestring >=0.1 && <0.3
-    , text >=0.11 && <1.3
+    , streaming-bytestring >=0.1
+    , text >=0.11
     , time >=1.8
     , timerep >=2.0
     , tls >=1.4.1
@@ -174,8 +174,8 @@ test-suite spec
     , process
     , safe-exceptions >=0.1.0.0
     , stm >=2.4
-    , streaming-bytestring >=0.1 && <0.3
-    , text >=0.11 && <1.3
+    , streaming-bytestring >=0.1
+    , text >=0.11
     , time >=1.8
     , timerep >=2.0
     , tls >=1.4.1

--- a/kubernetes-client/package.yaml
+++ b/kubernetes-client/package.yaml
@@ -6,15 +6,15 @@ description: |
   This package contains hand-written code while kubernetes-client-core contains code auto-generated from the OpenAPI spec.
 synopsis: Client library for Kubernetes
 maintainer:
-- Shimin Guo <smguo2001@gmail.com>
-- Akshay Mankar <itsakshaymankar@gmail.com>
+  - Shimin Guo <smguo2001@gmail.com>
+  - Akshay Mankar <itsakshaymankar@gmail.com>
 category: Web
 license: Apache-2.0
 license-file: LICENSE
 library:
   source-dirs: src
   ghc-options:
-  - -Wall
+    - -Wall
 tests:
   spec:
     main: Spec.hs
@@ -45,6 +45,7 @@ dependencies:
   - data-default-class >=0.1
   - either >=5.0
   - filepath >=1.4
+  - hashable
   - hoauth2 >=1.11 && <=3
   - http-client >=0.5 && <0.8
   - http-client-tls >=0.3
@@ -54,6 +55,7 @@ dependencies:
   - mtl >=2.2
   - oidc-client >=0.4
   - pem >=0.2
+  - process
   - safe-exceptions >=0.1.0.0
   - stm >=2.4
   - streaming-bytestring >= 0.1 && < 0.3
@@ -62,6 +64,7 @@ dependencies:
   - timerep >=2.0
   - tls >=1.4.1
   - typed-process >=0.2
+  - unordered-containers
   - uri-bytestring >=0.3
   - x509 >=1.7
   - x509-system >=1.6

--- a/kubernetes-client/package.yaml
+++ b/kubernetes-client/package.yaml
@@ -58,8 +58,8 @@ dependencies:
   - process
   - safe-exceptions >=0.1.0.0
   - stm >=2.4
-  - streaming-bytestring >= 0.1 && < 0.3
-  - text >=0.11 && <1.3
+  - streaming-bytestring >= 0.1
+  - text >=0.11
   - time >=1.8
   - timerep >=2.0
   - tls >=1.4.1

--- a/kubernetes-client/src/Kubernetes/Client/Auth/Exec.hs
+++ b/kubernetes-client/src/Kubernetes/Client/Auth/Exec.hs
@@ -1,0 +1,224 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Kubernetes.Client.Auth.Exec
+  ( -- * Authentication
+    Exec
+  , execAuth
+  , ExecAuthError (..)
+    -- * Token Info
+  , TokenInfo (..)
+  , Expiration (..)
+    -- * Cache
+  , Cache
+  , newCache
+    -- * gke-gcloud-auth-plugin
+  , decodeGkeGcloudAuthPluginToken
+  ) where
+
+import Control.Monad (when, void, forM_)
+import Control.Monad.STM (atomically)
+import Control.Concurrent (forkIO)
+import Control.Concurrent.MVar (MVar)
+import qualified Control.Concurrent.MVar as MVar
+import Control.Concurrent.STM.TVar (TVar)
+import qualified Control.Concurrent.STM.TVar as TVar
+import Control.Exception (Exception, catch, throwIO)
+import Data.Aeson (FromJSON (..), eitherDecodeStrict)
+import Data.Maybe (fromMaybe)
+import Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HashMap
+import Data.Text (Text, unpack)
+import Data.Time (UTCTime, getCurrentTime, addUTCTime)
+import Data.Typeable (typeOf)
+import GHC.Generics (Generic)
+import Kubernetes.Client.Auth.Internal.Types (DetectAuth)
+import Kubernetes.Client.KubeConfig (AuthInfo (..), ExecConfig (..), ExecEnvVar (..))
+import Kubernetes.OpenAPI.Core
+import qualified Data.ByteString.Char8 as ByteString
+import qualified System.Process as Process
+
+-------------------------------------------------------------------------------
+-- Authentication using Auth
+
+-- | Information about the token, as well as its expiration.
+data TokenInfo = TokenInfo
+  { tokenValue :: Text
+  , tokenExpiration :: Expiration
+  } deriving (Show)
+
+-- | What is the expiration time of the token.
+data Expiration = NeverExpires | SingleUse | ExpiresAt UTCTime
+    deriving (Show)
+
+-- | The command that is to be run to obtain the token
+data Exec = Exec
+  { config :: ExecConfig
+  , decodeToken :: String -> Either String TokenInfo
+  , refreshBefore :: Maybe Int
+  , cache :: Maybe Cache
+  }
+
+runExec :: Exec -> IO Text
+runExec exec =
+  case cache exec of
+    Nothing ->
+      tokenValue <$> runExecCommand exec
+    Just cache ->
+      lookupCache cache (refreshBefore exec) (config exec) (runExecCommand exec)
+
+data ExecAuthError = ExecCommandError IOError | ExecTokenParseError String
+  deriving (Show, Exception)
+
+runExecCommand :: Exec -> IO TokenInfo
+runExecCommand Exec { config = ExecConfig {..}, decodeToken } = do
+  let
+    environment =
+      fmap (fmap (\ExecEnvVar {..} -> (unpack name, unpack value))) env
+
+    process =
+      (Process.proc (unpack command) (fmap unpack $ fromMaybe [] args))
+        { Process.env = environment }
+
+  output <-
+    catch (Process.readCreateProcess process "") $ \err ->
+      throwIO $ ExecCommandError err
+
+  case decodeToken output of
+    Left err ->
+      throwIO $ ExecTokenParseError err
+    Right ok ->
+      pure ok
+
+instance AuthMethod Exec where
+  applyAuthMethod _ plugin req = do
+    token <- runExec plugin
+    pure $
+      if (typeOf plugin `elem` rAuthTypes req)
+        then
+          (req `setHeader` toHeader ("Authorization", "Bearer " <> token))
+          { rAuthTypes = [] }
+        else
+          req
+
+-- | Defines the 'exec' authentication method.
+execAuth ::
+  -- | Whether to use a cache or not. The cache can be created with @newCache@.
+  Maybe Cache ->
+  -- | Amount of minutes before the expiration time where token refreshing
+  -- should be retried in the background.
+  Maybe Int ->
+  -- | Function used to decode the output of the executed plugin.
+  (String -> Either String TokenInfo) -> DetectAuth
+execAuth mcache refreshBefore decodeToken AuthInfo {exec} (tlsParams, cfg) = do
+  config <- exec
+  pure $
+    pure
+      ( tlsParams
+      , cfg
+          { configAuthMethods = [AnyAuthMethod (Exec config decodeToken refreshBefore mcache)]
+          }
+      )
+
+--------------------------------------------------------------------------------
+-- Cache
+
+-- The cache for token info. It is a TVar so it can be reused by multiple
+-- threads, and each token is in a MVar so there are no multiple threads trying
+-- to update the same key.
+newtype Cache = Cache (TVar (HashMap ExecConfig (MVar TokenInfo)))
+
+newCache :: IO Cache
+newCache = Cache <$> TVar.newTVarIO HashMap.empty
+
+lookupCache :: Cache -> Maybe Int -> ExecConfig -> IO TokenInfo -> IO Text
+lookupCache (Cache tvar) refreshBefore config getTokenInfo = do
+
+  let renewTVar possibleMVar isBlocking = do
+        mvar <- case possibleMVar of
+          -- If there is no MVar in scope, it needs to be created and added to
+          -- the TVar.
+          Nothing -> do
+            mvar <- MVar.newEmptyMVar
+            atomically $ TVar.modifyTVar tvar (HashMap.insert config mvar)
+            pure mvar
+
+          -- Otherwise, we can just reuse it.
+          Just mvar -> do
+            when isBlocking $ do
+              void $ MVar.takeMVar mvar
+            pure mvar
+
+        -- Get the TokenInfo
+        tokenInfo <- getTokenInfo
+
+        -- Fill the mvar with the existing info
+        if isBlocking
+          then
+            -- Here the MVar is empty
+            MVar.putMVar mvar tokenInfo
+          else
+            -- Here the MVar is filled
+            void $ MVar.swapMVar mvar tokenInfo
+
+        -- Return the token
+        pure (tokenValue tokenInfo)
+
+  hashmap <- TVar.readTVarIO tvar
+
+  case HashMap.lookup config hashmap of
+    Nothing ->
+      -- In this case, the MVar will be created for the first time, otherwise
+      -- the value it holds will be updated
+      renewTVar Nothing True
+    Just mvar -> do
+      let renew = renewTVar (Just mvar)
+      TokenInfo value mexpiration <- MVar.readMVar mvar
+      case mexpiration of
+        NeverExpires ->
+          -- We can just reuse the value
+          pure value
+        SingleUse ->
+          -- No need to use the cache, just retrieve the token
+          tokenValue <$> getTokenInfo
+        ExpiresAt expiration -> do
+          now <- getCurrentTime
+          if now > expiration
+          then
+            -- Here the key is expired, so the renewal should be blocking
+            renew True
+          else do
+            forM_ refreshBefore $ \minutes ->
+              when (addUTCTime (realToFrac minutes * 60) now > expiration) $
+                -- Here the key is not expired, but we are close enough to
+                -- expiration to ask for a new one in the background, so the
+                -- renewal should not be blocking
+                void $ forkIO $ void $ renew False
+            pure value
+
+-------------------------------------------------------------------------------
+-- gke-gcloud-auth-plugin
+
+-- | The result that is written to stdout
+data Result = Result
+  { kind :: Text
+  , apiVersion :: Text
+  , status :: Status
+  } deriving (Show, Generic)
+    deriving (FromJSON)
+
+data Status = Status
+  { expirationTimestamp :: UTCTime
+  , token :: Text
+  } deriving (Show, Generic)
+    deriving (FromJSON)
+
+decodeGkeGcloudAuthPluginToken :: String -> Either String TokenInfo
+decodeGkeGcloudAuthPluginToken str = do
+  Result { status = Status { token, expirationTimestamp } } <-
+    eitherDecodeStrict (ByteString.pack str)
+  pure $ TokenInfo token (ExpiresAt expirationTimestamp)

--- a/kubernetes-client/src/Kubernetes/Client/Auth/OIDC.hs
+++ b/kubernetes-client/src/Kubernetes/Client/Auth/OIDC.hs
@@ -60,7 +60,7 @@ instance AuthMethod OIDCAuth where
       $ setHeader req [("Authorization", "Bearer " <> (Text.encodeUtf8 token))]
       & L.set rAuthTypesL []
 
-data OIDCGetTokenException = OIDCOAuthException (OAuth2Error OAuth2TokenRequest.Errors)
+data OIDCGetTokenException = OIDCOAuthException TokenRequestError
                            | OIDCURIException URIParseError
                            | OIDCGetTokenException String
   deriving Show

--- a/kubernetes/kubernetes-client-core.cabal
+++ b/kubernetes/kubernetes-client-core.cabal
@@ -43,7 +43,7 @@ library
     , containers >=0.5.0.0 && <0.8
     , deepseq >= 1.4 && <1.6
     , exceptions >= 0.4
-    , http-api-data >= 0.3.4 && <0.5
+    , http-api-data >= 0.3.4
     , http-client >=0.5 && <0.8
     , http-client-tls
     , http-media >= 0.4 && < 0.9
@@ -54,11 +54,11 @@ library
     , network >=2.6.2 && <3.9
     , random >=1.1
     , safe-exceptions <0.2
-    , text >=0.11 && <1.3
+    , text >=0.11
     , time >=1.5
     , transformers >=0.4.0.0
     , unordered-containers
-    , vector >=0.10.9 && <0.13
+    , vector >=0.10.9
   other-modules:
       Paths_kubernetes_client_core
       Kubernetes.OpenAPI.ImportMappings

--- a/kubernetes/stack.yaml
+++ b/kubernetes/stack.yaml
@@ -1,4 +1,5 @@
-resolver: lts-19.6
+resolver: lts-20.11
+compiler: ghc-9.2.5
 build:
   haddock-arguments:
     haddock-args:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,10 @@
-resolver: lts-20.11
-compiler: ghc-9.2.5
+resolver: lts-21.9
+compiler: ghc-9.4.6
 
 extra-deps:
-- jsonpath-0.2.1.0
-- oidc-client-0.7.0.1
+  - jsonpath-0.2.1.0
+  - oidc-client-0.7.0.1
 
 packages:
-- kubernetes
-- kubernetes-client
+  - kubernetes
+  - kubernetes-client

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -20,7 +20,7 @@ packages:
     hackage: oidc-client-0.7.0.1
 snapshots:
 - completed:
-    sha256: adbc602422dde10cc330175da7de8609e70afc41449a7e2d6e8b1827aa0e5008
-    size: 649342
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/11.yaml
-  original: lts-20.11
+    sha256: 2fc12a405ab6f7eac73eb11a0ca5ccca0e956bd2848db780c140b7406ff9ebb5
+    size: 640035
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/9.yaml
+  original: lts-21.9


### PR DESCRIPTION
This PR adds support for the `exec` authentication method, notably so that the library can use `gke-gcloud-auth-plugin` to fetch tokens. It has some support for optional caching of tokens, and early refresh when supported. We have been using this in production for some time, so it is working well enough, but suggestions are more than welcome.

There are also some small refactors to the exposed functions to allow for a more flexible choice of authentication methods.