### PR TITLE
Add support for ghc-9.14

### DIFF
--- a/kubernetes-client/src/Kubernetes/Client/Auth/OIDC.hs
+++ b/kubernetes-client/src/Kubernetes/Client/Auth/OIDC.hs
@@ -15,7 +15,7 @@ import Data.Either.Combinators
 import Data.Function                         ((&))
 import Data.Map                              (Map)
 import Data.Maybe
-import Data.Text
+import Data.Text                             hiding (show)
 import Data.Text.Encoding                    (encodeUtf8)
 import Data.Time.Clock.POSIX                 (getPOSIXTime)
 import Jose.Jwt

--- a/kubernetes-client/src/Kubernetes/Client/Auth/OIDC.hs
+++ b/kubernetes-client/src/Kubernetes/Client/Auth/OIDC.hs
@@ -25,7 +25,7 @@ import Kubernetes.Client.KubeConfig
 import Kubernetes.OpenAPI.Core
 import Network.HTTP.Client
 import Network.HTTP.Client.TLS
-import Network.OAuth.OAuth2                  as OAuth
+import Network.OAuth2                        as OAuth
 import Network.TLS                           as TLS
 import URI.ByteString
 import Web.OIDC.Client.Discovery             as OIDC

--- a/kubernetes-client/src/Kubernetes/Data/K8sJSONPath.hs
+++ b/kubernetes-client/src/Kubernetes/Data/K8sJSONPath.hs
@@ -7,7 +7,7 @@ import Data.Aeson
 import Data.Aeson.Text
 import Data.Bifunctor
 import Data.JSONPath
-import Data.Text       as Text
+import Data.Text       as Text hiding (show)
 import Data.Text.Lazy       (toStrict)
 
 #if !MIN_VERSION_base(4,11,0)


### PR DESCRIPTION
This PR allows building kubernetes-client with latest dependencies, e.g. using in cabal.project:

```
packages: .
allow-newer: kubernetes-client:*, kubernetes-client-core:*, http-media:containers

source-repository-package
    type: git
    location: https://github.com/TristanCacqueray/kubernetes-client-haskell
    tag: 89f3c0f2ca115c074e6d947ee3118c13a6005233
    subdir: kubernetes-1.30 kubernetes-client
```